### PR TITLE
Translate Chinese content to Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,61 +6,61 @@
 
 <h1 align="center">vue-fastapi-admin</h1>
 
-[English](./README-en.md) | 简体中文
+[English](./README-en.md) | 한국어
 
-基于 FastAPI + Vue3 + Naive UI 的现代化前后端分离开发平台，融合了 RBAC 权限管理、动态路由和 JWT 鉴权，助力中小型应用快速搭建，也可用于学习参考。
+FastAPI + Vue3 + Naive UI 기반의 현대적인 프론트엔드-백엔드 분리 개발 플랫폼으로, RBAC 권한 관리, 동적 라우팅 및 JWT 인증을 통합하여 중소 규모 애플리케이션의 빠른 구축을 지원하며 학습 참고용으로도 사용할 수 있습니다.
 
-### 特性
-- **最流行技术栈**：基于 Python 3.11 和 FastAPI 高性能异步框架，结合 Vue3 和 Vite 等前沿技术进行开发，同时使用高效的 npm 包管理器 pnpm。
-- **代码规范**：项目内置丰富的规范插件，确保代码质量和一致性，有效提高团队协作效率。
-- **动态路由**：后端动态路由，结合 RBAC（Role-Based Access Control）权限模型，提供精细的菜单路由控制。
-- **JWT鉴权**：使用 JSON Web Token（JWT）进行身份验证和授权，增强应用的安全性。
-- **细粒度权限控制**：实现按钮和接口级别的权限控制，确保不同用户或角色在界面操作和接口访问时具有不同的权限限制。
+### 특징
+- **최신 기술 스택**: Python 3.11 및 FastAPI 고성능 비동기 프레임워크를 기반으로 하며, Vue3 및 Vite와 같은 최첨단 기술을 결합하여 개발되었으며 효율적인 npm 패키지 관리자인 pnpm을 사용합니다.
+- **코드 규범**: 프로젝트에는 풍부한 규범 플러그인이 내장되어 코드 품질과 일관성을 보장하고 팀 협업 효율성을 효과적으로 향상시킵니다.
+- **동적 라우팅**: 백엔드 동적 라우팅은 RBAC(Role-Based Access Control) 권한 모델과 결합되어 세분화된 메뉴 라우팅 제어를 제공합니다.
+- **JWT 인증**: JSON Web Token(JWT)을 사용하여 신원 확인 및 권한 부여를 수행하여 애플리케이션 보안을 강화합니다.
+- **세분화된 권한 제어**: 버튼 및 인터페이스 수준의 권한 제어를 구현하여 다양한 사용자 또는 역할이 인터페이스 작업 및 인터페이스 액세스 시 서로 다른 권한 제한을 갖도록 보장합니다.
 
-### 在线预览
+### 온라인 미리보기
 - [http://47.111.145.81:3000](http://47.111.145.81:3000)
 - username: admin
 - password: 123456
 
-### 登录页
+### 로그인 페이지
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/login.jpg)
-### 工作台
+### 작업 공간
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/workbench.jpg)
 
-### 用户管理
+### 사용자 관리
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/user.jpg)
-### 角色管理
+### 역할 관리
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/role.jpg)
 
-### 菜单管理
+### 메뉴 관리
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/menu.jpg)
 
-### API管理
+### API 관리
 
 ![image](https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/api.jpg)
 
-### 快速开始
-#### 方法一：dockerhub拉取镜像
+### 빠른 시작
+#### 방법 1: Docker Hub에서 이미지 가져오기
 
 ```sh
 docker pull mizhexiaoxiao/vue-fastapi-admin:latest 
 docker run -d --restart=always --name=vue-fastapi-admin -p 9999:80 mizhexiaoxiao/vue-fastapi-admin
 ```
 
-#### 方法二：dockerfile构建镜像
-##### docker安装(版本17.05+)
+#### 방법 2: Dockerfile로 이미지 빌드
+##### Docker 설치 (버전 17.05+)
 
 ```sh
 yum install -y docker-ce
 systemctl start docker
 ```
 
-##### 构建镜像
+##### 이미지 빌드
 
 ```sh
 git clone https://github.com/mizhexiaoxiao/vue-fastapi-admin.git
@@ -68,13 +68,13 @@ cd vue-fastapi-admin
 docker build --no-cache . -t vue-fastapi-admin
 ```
 
-##### 启动容器
+##### 컨테이너 시작
 
 ```sh
 docker run -d --restart=always --name=vue-fastapi-admin -p 9999:80 vue-fastapi-admin
 ```
 
-##### 访问
+##### 접속
 
 http://localhost:9999
 
@@ -82,160 +82,160 @@ username：admin
 
 password：123456
 
-### 本地启动
-#### 后端
-启动项目需要以下环境：
+### 로컬에서 시작하기
+#### 백엔드
+프로젝트를 시작하려면 다음 환경이 필요합니다:
 - Python 3.11
 
-#### 方法一（推荐）：使用 uv 安装依赖
-1. 安装 uv
+#### 방법 1 (권장): uv를 사용하여 의존성 설치
+1. uv 설치
 ```sh
 pip install uv
 ```
 
-2. 创建并激活虚拟环境
+2. 가상 환경 생성 및 활성화
 ```sh
 uv venv
 source .venv/bin/activate  # Linux/Mac
-# 或
+# 또는
 .\.venv\Scripts\activate  # Windows
 ```
 
-3. 安装依赖
+3. 의존성 설치
 ```sh
 uv add pyproject.toml
 ```
 
-4. 启动服务
+4. 서비스 시작
 ```sh
 python run.py
 ```
 
-#### 方法二：使用 Pip 安装依赖
-1. 创建虚拟环境
+#### 방법 2: Pip를 사용하여 의존성 설치
+1. 가상 환경 생성
 ```sh
 python3 -m venv venv
 ```
 
-2. 激活虚拟环境
+2. 가상 환경 활성화
 ```sh
 source venv/bin/activate  # Linux/Mac
-# 或
+# 또는
 .\venv\Scripts\activate  # Windows
 ```
 
-3. 安装依赖
+3. 의존성 설치
 ```sh
 pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
-4. 启动服务
+4. 서비스 시작
 ```sh
 python run.py
 ```
 
-服务现在应该正在运行，访问 http://localhost:9999/docs 查看API文档
+이제 서비스가 실행 중이어야 합니다. API 문서를 보려면 http://localhost:9999/docs 에 접속하세요.
 
-#### 前端
-启动项目需要以下环境：
+#### 프론트엔드
+프로젝트를 시작하려면 다음 환경이 필요합니다:
 - node v18.8.0+
 
-1. 进入前端目录
+1. 프론트엔드 디렉토리로 이동
 ```sh
 cd web
 ```
 
-2. 安装依赖(建议使用pnpm: https://pnpm.io/zh/installation)
+2. 의존성 설치 (pnpm 사용 권장: https://pnpm.io/zh/installation)
 ```sh
-npm i -g pnpm # 已安装可忽略
-pnpm i # 或者 npm i
+npm i -g pnpm # 이미 설치된 경우 무시
+pnpm i # 또는 npm i
 ```
 
-3. 启动
+3. 시작
 ```sh
 pnpm dev
 ```
 
-### 目录说明
+### 디렉토리 설명
 
 ```
-├── app                   // 应用程序目录
-│   ├── api               // API接口目录
-│   │   └── v1            // 版本1的API接口
-│   │       ├── apis      // API相关接口
-│   │       ├── base      // 基础信息接口
-│   │       ├── menus     // 菜单相关接口
-│   │       ├── roles     // 角色相关接口
-│   │       └── users     // 用户相关接口
-│   ├── controllers       // 控制器目录
-│   ├── core              // 核心功能模块
-│   ├── log               // 日志目录
-│   ├── models            // 数据模型目录
-│   ├── schemas           // 数据模式/结构定义
-│   ├── settings          // 配置设置目录
-│   └── utils             // 工具类目录
-├── deploy                // 部署相关目录
-│   └── sample-picture    // 示例图片目录
-└── web                   // 前端网页目录
-    ├── build             // 构建脚本和配置目录
-    │   ├── config        // 构建配置
-    │   ├── plugin        // 构建插件
-    │   └── script        // 构建脚本
-    ├── public            // 公共资源目录
-    │   └── resource      // 公共资源文件
-    ├── settings          // 前端项目配置
-    └── src               // 源代码目录
-        ├── api           // API接口定义
-        ├── assets        // 静态资源目录
-        │   ├── images    // 图片资源
-        │   ├── js        // JavaScript文件
-        │   └── svg       // SVG矢量图文件
-        ├── components    // 组件目录
-        │   ├── common    // 通用组件
-        │   ├── icon      // 图标组件
-        │   ├── page      // 页面组件
-        │   ├── query-bar // 查询栏组件
-        │   └── table     // 表格组件
-        ├── composables   // 可组合式功能块
-        ├── directives    // 指令目录
-        ├── layout        // 布局目录
-        │   └── components // 布局组件
-        ├── router        // 路由目录
-        │   ├── guard     // 路由守卫
-        │   └── routes    // 路由定义
-        ├── store         // 状态管理(pinia)
-        │   └── modules   // 状态模块
-        ├── styles        // 样式文件目录
-        ├── utils         // 工具类目录
-        │   ├── auth      // 认证相关工具
-        │   ├── common    // 通用工具
-        │   ├── http      // 封装axios
-        │   └── storage   // 封装localStorage和sessionStorage
-        └── views         // 视图/页面目录
-            ├── error-page // 错误页面
-            ├── login      // 登录页面
-            ├── profile    // 个人资料页面
-            ├── system     // 系统管理页面
-            └── workbench  // 工作台页面
+├── app                   // 애플리케이션 디렉토리
+│   ├── api               // API 인터페이스 디렉토리
+│   │   └── v1            // 버전 1 API 인터페이스
+│   │       ├── apis      // API 관련 인터페이스
+│   │       ├── base      // 기본 정보 인터페이스
+│   │       ├── menus     // 메뉴 관련 인터페이스
+│   │       ├── roles     // 역할 관련 인터페이스
+│   │       └── users     // 사용자 관련 인터페이스
+│   ├── controllers       // 컨트롤러 디렉토리
+│   ├── core              // 핵심 기능 모듈
+│   ├── log               // 로그 디렉토리
+│   ├── models            // 데이터 모델 디렉토리
+│   ├── schemas           // 데이터 스키마/구조 정의
+│   ├── settings          // 구성 설정 디렉토리
+│   └── utils             // 유틸리티 디렉토리
+├── deploy                // 배포 관련 디렉토리
+│   └── sample-picture    // 샘플 이미지 디렉토리
+└── web                   // 프론트엔드 웹 디렉토리
+    ├── build             // 빌드 스크립트 및 구성 디렉토리
+    │   ├── config        // 빌드 구성
+    │   ├── plugin        // 빌드 플러그인
+    │   └── script        // 빌드 스크립트
+    ├── public            // 공용 리소스 디렉토리
+    │   └── resource      // 공용 리소스 파일
+    ├── settings          // 프론트엔드 프로젝트 구성
+    └── src               // 소스 코드 디렉토리
+        ├── api           // API 인터페이스 정의
+        ├── assets        // 정적 리소스 디렉토리
+        │   ├── images    // 이미지 리소스
+        │   ├── js        // JavaScript 파일
+        │   └── svg       // SVG 벡터 이미지 파일
+        ├── components    // 컴포넌트 디렉토리
+        │   ├── common    // 공용 컴포넌트
+        │   ├── icon      // 아이콘 컴포넌트
+        │   ├── page      // 페이지 컴포넌트
+        │   ├── query-bar // 검색 바 컴포넌트
+        │   └── table     // 테이블 컴포넌트
+        ├── composables   // 조합 가능한 기능 블록
+        ├── directives    // 디렉티브 디렉토리
+        ├── layout        // 레이아웃 디렉토리
+        │   └── components // 레이아웃 컴포넌트
+        ├── router        // 라우터 디렉토리
+        │   ├── guard     // 라우트 가드
+        │   └── routes    // 라우트 정의
+        ├── store         // 상태 관리 (pinia)
+        │   └── modules   // 상태 모듈
+        ├── styles        // 스타일 파일 디렉토리
+        ├── utils         // 유틸리티 디렉토리
+        │   ├── auth      // 인증 관련 유틸리티
+        │   ├── common    // 공용 유틸리티
+        │   ├── http      // axios 래퍼
+        │   └── storage   // localStorage 및 sessionStorage 래퍼
+        └── views         // 뷰/페이지 디렉토리
+            ├── error-page // 오류 페이지
+            ├── login      // 로그인 페이지
+            ├── profile    // 개인 프로필 페이지
+            ├── system     // 시스템 관리 페이지
+            └── workbench  // 작업 공간 페이지
 ```
 
-### 进群交流
-进群的条件是给项目一个star，小小的star是作者维护下去的动力。
+### 그룹 채팅 참여
+그룹에 참여하는 조건은 프로젝트에 스타를 주는 것입니다. 작은 스타는 작가가 계속 유지하는 원동력입니다.
 
-你可以在群里提出任何疑问，我会尽快回复答疑。
+그룹에서 어떤 질문이든 할 수 있으며, 최대한 빨리 답변해 드리겠습니다.
 
 <img width="300" src="https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/group.jpg">
 
-## 打赏
-如果项目有帮助到你，可以请作者喝杯咖啡~
+## 후원
+프로젝트가 도움이 되었다면 작가에게 커피 한 잔 사주실 수 있습니다~
 
 <div style="display: flex">
     <img src="https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/1.jpg" width="300">
     <img src="https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/2.jpg" width="300">
 </div>
 
-## 定制开发
-如果有基于该项目的定制需求或其他合作，请添加下方微信，备注来意
+## 맞춤 개발
+이 프로젝트를 기반으로 한 맞춤 개발 요구 사항이나 기타 협력이 있으시면 아래 위챗을 추가하고 방문 목적을 알려주십시오.
 
 <img width="300" src="https://github.com/mizhexiaoxiao/vue-fastapi-admin/blob/main/deploy/sample-picture/3.jpg">
 

--- a/app/controllers/user.py
+++ b/app/controllers/user.py
@@ -35,12 +35,12 @@ class UserController(CRUDBase[User, UserCreate, UserUpdate]):
     async def authenticate(self, credentials: CredentialsSchema) -> Optional["User"]:
         user = await self.model.filter(username=credentials.username).first()
         if not user:
-            raise HTTPException(status_code=400, detail="无效的用户名")
+            raise HTTPException(status_code=400, detail="잘못된 사용자 이름입니다.")
         verified = verify_password(credentials.password, user.password)
         if not verified:
-            raise HTTPException(status_code=400, detail="密码错误!")
+            raise HTTPException(status_code=400, detail="비밀번호가 잘못되었습니다!")
         if not user.is_active:
-            raise HTTPException(status_code=400, detail="用户已被禁用")
+            raise HTTPException(status_code=400, detail="사용자가 비활성화되었습니다.")
         return user
 
     async def update_roles(self, user: User, role_ids: List[int]) -> None:
@@ -52,7 +52,7 @@ class UserController(CRUDBase[User, UserCreate, UserUpdate]):
     async def reset_password(self, user_id: int):
         user_obj = await self.get(id=user_id)
         if user_obj.is_superuser:
-            raise HTTPException(status_code=403, detail="不允许重置超级管理员密码")
+            raise HTTPException(status_code=403, detail="슈퍼 관리자의 비밀번호는 재설정할 수 없습니다.")
         user_obj.password = get_password_hash(password="123456")
         await user_obj.save()
 

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -15,7 +15,7 @@ class SettingNotFound(Exception):
 async def DoesNotExistHandle(req: Request, exc: DoesNotExist) -> JSONResponse:
     content = dict(
         code=404,
-        msg=f"Object has not found, exc: {exc}, query_params: {req.query_params}",
+        msg=f"객체를 찾을 수 없습니다, exc: {exc}, query_params: {req.query_params}",
     )
     return JSONResponse(content=content, status_code=404)
 
@@ -23,7 +23,7 @@ async def DoesNotExistHandle(req: Request, exc: DoesNotExist) -> JSONResponse:
 async def IntegrityHandle(_: Request, exc: IntegrityError) -> JSONResponse:
     content = dict(
         code=500,
-        msg=f"IntegrityError，{exc}",
+        msg=f"무결성 오류，{exc}",
     )
     return JSONResponse(content=content, status_code=500)
 

--- a/app/models/admin.py
+++ b/app/models/admin.py
@@ -7,24 +7,24 @@ from .enums import MethodType
 
 
 class User(BaseModel, TimestampMixin):
-    username = fields.CharField(max_length=20, unique=True, description="用户名称", index=True)
-    alias = fields.CharField(max_length=30, null=True, description="姓名", index=True)
-    email = fields.CharField(max_length=255, unique=True, description="邮箱", index=True)
-    phone = fields.CharField(max_length=20, null=True, description="电话", index=True)
-    password = fields.CharField(max_length=128, null=True, description="密码")
-    is_active = fields.BooleanField(default=True, description="是否激活", index=True)
-    is_superuser = fields.BooleanField(default=False, description="是否为超级管理员", index=True)
-    last_login = fields.DatetimeField(null=True, description="最后登录时间", index=True)
+    username = fields.CharField(max_length=20, unique=True, description="사용자 이름", index=True)
+    alias = fields.CharField(max_length=30, null=True, description="이름", index=True)
+    email = fields.CharField(max_length=255, unique=True, description="이메일", index=True)
+    phone = fields.CharField(max_length=20, null=True, description="전화번호", index=True)
+    password = fields.CharField(max_length=128, null=True, description="비밀번호")
+    is_active = fields.BooleanField(default=True, description="활성화 여부", index=True)
+    is_superuser = fields.BooleanField(default=False, description="슈퍼 관리자 여부", index=True)
+    last_login = fields.DatetimeField(null=True, description="마지막 로그인 시간", index=True)
     roles = fields.ManyToManyField("models.Role", related_name="user_roles")
-    dept_id = fields.IntField(null=True, description="部门ID", index=True)
+    dept_id = fields.IntField(null=True, description="부서 ID", index=True)
 
     class Meta:
         table = "user"
 
 
 class Role(BaseModel, TimestampMixin):
-    name = fields.CharField(max_length=20, unique=True, description="角色名称", index=True)
-    desc = fields.CharField(max_length=500, null=True, description="角色描述")
+    name = fields.CharField(max_length=20, unique=True, description="역할 이름", index=True)
+    desc = fields.CharField(max_length=500, null=True, description="역할 설명")
     menus = fields.ManyToManyField("models.Menu", related_name="role_menus")
     apis = fields.ManyToManyField("models.Api", related_name="role_apis")
 
@@ -33,57 +33,57 @@ class Role(BaseModel, TimestampMixin):
 
 
 class Api(BaseModel, TimestampMixin):
-    path = fields.CharField(max_length=100, description="API路径", index=True)
-    method = fields.CharEnumField(MethodType, description="请求方法", index=True)
-    summary = fields.CharField(max_length=500, description="请求简介", index=True)
-    tags = fields.CharField(max_length=100, description="API标签", index=True)
+    path = fields.CharField(max_length=100, description="API 경로", index=True)
+    method = fields.CharEnumField(MethodType, description="요청 방법", index=True)
+    summary = fields.CharField(max_length=500, description="요청 요약", index=True)
+    tags = fields.CharField(max_length=100, description="API 태그", index=True)
 
     class Meta:
         table = "api"
 
 
 class Menu(BaseModel, TimestampMixin):
-    name = fields.CharField(max_length=20, description="菜单名称", index=True)
-    remark = fields.JSONField(null=True, description="保留字段")
-    menu_type = fields.CharEnumField(MenuType, null=True, description="菜单类型")
-    icon = fields.CharField(max_length=100, null=True, description="菜单图标")
-    path = fields.CharField(max_length=100, description="菜单路径", index=True)
-    order = fields.IntField(default=0, description="排序", index=True)
-    parent_id = fields.IntField(default=0, description="父菜单ID", index=True)
-    is_hidden = fields.BooleanField(default=False, description="是否隐藏")
-    component = fields.CharField(max_length=100, description="组件")
-    keepalive = fields.BooleanField(default=True, description="存活")
-    redirect = fields.CharField(max_length=100, null=True, description="重定向")
+    name = fields.CharField(max_length=20, description="메뉴 이름", index=True)
+    remark = fields.JSONField(null=True, description="예약 필드")
+    menu_type = fields.CharEnumField(MenuType, null=True, description="메뉴 유형")
+    icon = fields.CharField(max_length=100, null=True, description="메뉴 아이콘")
+    path = fields.CharField(max_length=100, description="메뉴 경로", index=True)
+    order = fields.IntField(default=0, description="정렬", index=True)
+    parent_id = fields.IntField(default=0, description="상위 메뉴 ID", index=True)
+    is_hidden = fields.BooleanField(default=False, description="숨김 여부")
+    component = fields.CharField(max_length=100, description="컴포넌트")
+    keepalive = fields.BooleanField(default=True, description="활성 상태")
+    redirect = fields.CharField(max_length=100, null=True, description="리디렉션")
 
     class Meta:
         table = "menu"
 
 
 class Dept(BaseModel, TimestampMixin):
-    name = fields.CharField(max_length=20, unique=True, description="部门名称", index=True)
-    desc = fields.CharField(max_length=500, null=True, description="备注")
-    is_deleted = fields.BooleanField(default=False, description="软删除标记", index=True)
-    order = fields.IntField(default=0, description="排序", index=True)
-    parent_id = fields.IntField(default=0, max_length=10, description="父部门ID", index=True)
+    name = fields.CharField(max_length=20, unique=True, description="부서 이름", index=True)
+    desc = fields.CharField(max_length=500, null=True, description="비고")
+    is_deleted = fields.BooleanField(default=False, description="소프트 삭제 플래그", index=True)
+    order = fields.IntField(default=0, description="정렬", index=True)
+    parent_id = fields.IntField(default=0, max_length=10, description="상위 부서 ID", index=True)
 
     class Meta:
         table = "dept"
 
 
 class DeptClosure(BaseModel, TimestampMixin):
-    ancestor = fields.IntField(description="父代", index=True)
-    descendant = fields.IntField(description="子代", index=True)
-    level = fields.IntField(default=0, description="深度", index=True)
+    ancestor = fields.IntField(description="상위 항목", index=True)
+    descendant = fields.IntField(description="하위 항목", index=True)
+    level = fields.IntField(default=0, description="깊이", index=True)
 
 
 class AuditLog(BaseModel, TimestampMixin):
-    user_id = fields.IntField(description="用户ID", index=True)
-    username = fields.CharField(max_length=64, default="", description="用户名称", index=True)
-    module = fields.CharField(max_length=64, default="", description="功能模块", index=True)
-    summary = fields.CharField(max_length=128, default="", description="请求描述", index=True)
-    method = fields.CharField(max_length=10, default="", description="请求方法", index=True)
-    path = fields.CharField(max_length=255, default="", description="请求路径", index=True)
-    status = fields.IntField(default=-1, description="状态码", index=True)
-    response_time = fields.IntField(default=0, description="响应时间(单位ms)", index=True)
-    request_args = fields.JSONField(null=True, description="请求参数")
-    response_body = fields.JSONField(null=True, description="返回数据")
+    user_id = fields.IntField(description="사용자 ID", index=True)
+    username = fields.CharField(max_length=64, default="", description="사용자 이름", index=True)
+    module = fields.CharField(max_length=64, default="", description="기능 모듈", index=True)
+    summary = fields.CharField(max_length=128, default="", description="요청 설명", index=True)
+    method = fields.CharField(max_length=10, default="", description="요청 방법", index=True)
+    path = fields.CharField(max_length=255, default="", description="요청 경로", index=True)
+    status = fields.IntField(default=-1, description="상태 코드", index=True)
+    response_time = fields.IntField(default=0, description="응답 시간(ms)", index=True)
+    request_args = fields.JSONField(null=True, description="요청 매개변수")
+    response_body = fields.JSONField(null=True, description="반환 데이터")

--- a/web/README.md
+++ b/web/README.md
@@ -1,19 +1,19 @@
-## 快速开始
+## 빠른 시작
 
-进入前端目录
+프론트엔드 디렉토리로 이동
 
 ```sh
 cd web
 ```
 
-安装依赖(建议使用pnpm: https://pnpm.io/zh/installation)
+의존성 설치 (pnpm 사용 권장: https://pnpm.io/zh/installation)
 
 ```sh
-npm i -g pnpm # 已安装可忽略
-pnpm i # 或者 npm i
+npm i -g pnpm # 이미 설치된 경우 무시
+pnpm i # 또는 npm i
 ```
 
-启动
+시작
 
 ```sh
 pnpm dev

--- a/web/i18n/messages/index.js
+++ b/web/i18n/messages/index.js
@@ -1,7 +1,9 @@
 import * as en from './en.json'
 import * as cn from './cn.json'
+import * as ko from './ko.json'
 
 export default {
   en,
   cn,
+  ko,
 }

--- a/web/i18n/messages/ko.json
+++ b/web/i18n/messages/ko.json
@@ -1,0 +1,62 @@
+{
+  "lang": "한국어",
+  "app_name": "Vue FastAPI Admin",
+  "header": {
+    "label_profile": "개인 정보",
+    "label_logout": "로그아웃",
+    "label_logout_dialog_title": "알림",
+    "text_logout_confirm": "로그아웃 하시겠습니까?",
+    "text_logout_success": "로그아웃 되었습니다"
+  },
+  "views": {
+    "login": {
+      "text_login": "로그인",
+      "message_input_username_password": "사용자 이름과 비밀번호를 입력하세요",
+      "message_verifying": "확인 중...",
+      "message_login_success": "로그인 성공"
+    },
+    "workbench": {
+      "label_workbench": "작업 공간",
+      "text_hello": "안녕하세요, {username}님",
+      "text_welcome": "오늘도 활기찬 하루 되세요!",
+      "label_number_of_items": "항목 수",
+      "label_upcoming": "예정",
+      "label_information": "정보",
+      "label_project": "프로젝트",
+      "label_more": "더 보기"
+    },
+    "profile": {
+      "label_profile": "개인 센터",
+      "label_modify_information": "정보 수정",
+      "label_change_password": "비밀번호 변경",
+      "label_avatar": "아바타",
+      "label_username": "사용자 이름",
+      "label_email": "이메일",
+      "label_old_password": "이전 비밀번호",
+      "label_new_password": "새 비밀번호",
+      "label_confirm_password": "비밀번호 확인",
+      "placeholder_username": "이름을 입력하세요",
+      "placeholder_email": "이메일을 입력하세요",
+      "placeholder_old_password": "이전 비밀번호를 입력하세요",
+      "placeholder_new_password": "새 비밀번호를 입력하세요",
+      "placeholder_confirm_password": "새 비밀번호를 다시 입력하세요",
+      "message_username_required": "닉네임을 입력하세요",
+      "message_old_password_required": "이전 비밀번호를 입력하세요",
+      "message_new_password_required": "새 비밀번호를 입력하세요",
+      "message_password_confirmation_required": "비밀번호를 다시 입력하세요",
+      "message_password_confirmation_diff": "두 비밀번호가 일치하지 않습니다"
+    },
+    "errors": {
+      "label_error": "오류 페이지",
+      "text_back_to_home": "홈으로 돌아가기"
+    }
+  },
+  "common": {
+    "text": {
+      "update_success": "수정 성공"
+    },
+    "buttons": {
+      "update": "수정"
+    }
+  }
+}


### PR DESCRIPTION
This commit translates all identified Chinese text in the codebase to Korean.

Key changes include:

- Frontend:
    - Added `web/i18n/messages/ko.json` with Korean translations for UI elements.
    - Updated `web/i18n/messages/index.js` to include the new Korean language file.
    - Translated `README.md` and `web/README.md` from Chinese to Korean.

- Backend:
    - Translated Chinese comments (e.g., model field descriptions in `app/models/admin.py`) to Korean.
    - Translated Chinese string literals (e.g., error messages in `app/controllers/user.py` and `app/core/exceptions.py`) to Korean.

The goal is to make the application and its documentation accessible to Korean-speaking users like you.